### PR TITLE
Fix CORS issue running timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ git push -u origin work
 ```
 
 Replace `<your-username>` and `<repo>` with your actual GitHub username and repository name.
+
+## Running the timer locally
+
+Because the scripts in `index.html` use ES modules, most browsers block them when opened directly from the filesystem. Use a simple HTTP server instead:
+
+```bash
+# From the project directory
+python3 -m http.server
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) in your browser and the timer will work correctly.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ python3 -m http.server
 ```
 
 Then visit [http://localhost:8000](http://localhost:8000) in your browser and the timer will work correctly.
+
+## Running tests
+
+To verify that the timer module loads correctly in Node, run:
+
+```bash
+npm test
+```
+
+This simple test checks the `Timer` class initialization.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "timer-app",
+  "version": "1.0.0",
+  "description": "Simple modular timer web app",
+  "scripts": {
+    "test": "node test/test.js"
+  },
+  "type": "module"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import { Timer } from '../js/timer.js';
+
+// Basic sanity test for Timer class
+const timer = new Timer(1, null, null);
+assert.strictEqual(timer.running, false);
+
+// start the timer
+timer.start();
+assert.strictEqual(timer.running, true);
+assert.ok(timer.startDate instanceof Date);
+
+// stop the timer immediately
+ timer.stop();
+assert.strictEqual(timer.running, false);
+console.log('tests passed');


### PR DESCRIPTION
## Summary
- document how to run the timer from a local HTTP server to avoid CORS errors

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68400f88c4f88325af29ee9a6de0331b